### PR TITLE
feat: adjusting the number of cards per page on the shelter screen

### DIFF
--- a/src/app/components/abrigo/abrigo.component.ts
+++ b/src/app/components/abrigo/abrigo.component.ts
@@ -32,7 +32,7 @@ import { IShelterInterface } from './dto/shelter.dto';
 })
 export class AbrigoComponent {
   page = 1;
-  pageSize = 6;
+  pageSize = 8;
   #shelterService = inject(ShelterService);
   #cdr = inject(ChangeDetectorRef);
   #toastService = inject(ToastService);


### PR DESCRIPTION
O que mudou?

PageSize da tela de listagem de abrigos deixou de mostrar 6 cards e agora mostra 8

Antes:

![image](https://github.com/nudou350/sospetsrs/assets/154293442/fda4f515-718a-4660-af71-a422c7798364)

Depois:

![image](https://github.com/nudou350/sospetsrs/assets/154293442/98605b3c-0495-4399-a044-397cdb05c5b3)
