### PR TITLE
feat: change the link for 'Ver mapa de resgate' button

### DIFF
--- a/src/app/components/home/components/home-banner/home-banner.component.ts
+++ b/src/app/components/home/components/home-banner/home-banner.component.ts
@@ -12,5 +12,5 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class HomeBannerComponent {
-  rescueMapUrl = "https://earth.google.com/earth/d/1puzq1GWwlCdW_ulmV2pv47bHGqD7AUyx?usp=sharing"
+  rescueMapUrl = "https://www.google.com/maps/d/u/3/edit?mid=1kjb746-UAeM6jELlcQ6g2o7MDHKVj4o&usp=sharing"
 }


### PR DESCRIPTION
#### Task no clickup
- **ID**: #86a3ev43r [Task](https://app.clickup.com/t/86a3ev43r)

#### Descrição Geral
- **Tipo de Mudança**: Nova Funcionalidade
- **Resumo**: 
  - Necessário alterar o link do botão "Ver mapas de resgate" para o link do google maps https://www.google.com/maps/d/u/3/edit?mid=1kjb746-UAeM6jELlcQ6g2o7MDHKVj4o&usp=sharing 
  pois hoje estamos direcionando o usuário para o google earth

#### Pendências
- **Trabalho Incompleto**:
  - Liste quaisquer partes do projeto que ainda precisam ser trabalhadas ou finalizadas em futuros PRs.

#### Visual
- **Screenshots**:
  - Inclua imagens ou screenshots que ajudem a visualizar as mudanças feitas, especialmente para alterações na UI. 
![image](https://github.com/nudou350/sospetsrs/assets/93841387/46faef51-fd90-45a0-a21e-744e2fdef050)


#### Comentários Adicionais
- **Notas**:
  - Critérios de aceite:
      1. Ao clicar no botão "Ver mapas de resgate" ser direcionado para o link do google maps - https://www.google.com/maps/d/u/3/edit?mid=1kjb746-UAeM6jELlcQ6g2o7MDHKVj4o&usp=sharing
      2. Alterar o link do botão tanto para acesso via desktop quanto para mobile.

- **Solicitações de Feedback Específico**:
  - Se houver áreas específicas sobre as quais você gostaria de receber feedback, mencione-as aqui.

#### Checklist de Submissão
- [x] O código segue as diretrizes de estilo e qualidade do projeto.
- [x] As mudanças foram testadas e funcionam adequadamente.
- [ ] A documentação foi atualizada conforme necessário.
