### PR TITLE
hotfix: fix title from home mobile

### DIFF
--- a/src/app/components/home/components/home-banner/home-banner.component.html
+++ b/src/app/components/home/components/home-banner/home-banner.component.html
@@ -1,9 +1,7 @@
 <div
   class="row align-content-end container-padding-x align-content-lg-center banner-container align-items-center position-relative overflow-x-hidden dog py-5">
   <div class="col-lg-6 col-10 col-md-8 text-lg-start text-justify pe-5 mt-5">
-    <h1 class="fw-bold pb-2 text-primary d-none d-lg-block">Proteção e esperança para animais em emergência</h1>
-    <h1 class="fw-bold text-primary d-lg-none w-50">Encontre <br /> seu pet aqui na Arcanimal</h1>
-    <p class="subtitle1-regular d-lg-none">Aqui você pode encontrar seu pet em poucos cliques!</p>
+    <h1 class="fw-bold pb-2 text-primary d-block">Proteção e esperança para animais em emergência</h1>
   </div>
   <div class="mt-5 col-md-12">
     <a [href]="rescueMapUrl" target="_blank" class="btn col-md-4 btn-primary fs-3 mt-lg-3 w-mobile">Ver mapa de resgate</a>

--- a/src/app/components/home/components/home-in-development/home-in-development.component.html
+++ b/src/app/components/home/components/home-in-development/home-in-development.component.html
@@ -3,8 +3,8 @@
     <img src="./../../../../../assets/img/background-in-development.svg" alt="Ilustração de um cachorro brincando">
   </div>
   <div class="col-12 col-lg-6">
-    <h1 class="fw-bold h1-md-bold h2-bold fw-bold pb-2 text-primary">Estamos em desenvolvimento</h1>
-    <p class="h3-medium fw-normal">Tem alguma crítica e/ou sugestão? Acesse o formulário abaixo e nos ajude
+    <h1 class="fw-bold fw-bold pb-2 text-primary">Estamos em desenvolvimento</h1>
+    <p class="h4-medium fw-normal">Tem alguma crítica e/ou sugestão? Acesse o formulário abaixo e nos ajude
       a melhorar!</p>
     <div class="d-flex justify-content-center py-5">
       <a [href]="feedbackFormUrl" target="_blank" class="d-flex gap-2 btn text-primary align-items-center pointer">


### PR DESCRIPTION
#### Task no clickup
- **ID**: Solicitação do whats 19/05

#### Descrição Geral
- **Tipo de Mudança**: Correção de Bug
- **Resumo**:
  - Removido subtitulo e trocado titulo da home no mobile.

#### Visual
- **Screenshots**:
 
Antes:
![localhost_4200_(iPhone 12 Pro)](https://github.com/nudou350/sospetsrs/assets/34607596/cc605cb4-1da9-48eb-b069-92413462e94b)


Depois:
![localhost_4200_](https://github.com/nudou350/sospetsrs/assets/34607596/49c799c5-f161-41a5-b866-d9faca564fa9)



#### Checklist de Submissão
- [x] O código segue as diretrizes de estilo e qualidade do projeto.
- [x] As mudanças foram testadas e funcionam adequadamente.
- [ ] A documentação foi atualizada conforme necessário.
